### PR TITLE
Fixed issue #6 - Test case 'testSignalObserver'

### DIFF
--- a/test/change_observer_test.cpp
+++ b/test/change_observer_test.cpp
@@ -33,7 +33,6 @@
 #include "change_observer_test.hpp"
 #include <chrono>
 #include <thread>
-#include <dlib/misc_api.h>
 
 // Registers the fixture into the 'registry'
 CPPUNIT_TEST_SUITE_REGISTRATION(ChangeObserverTest);
@@ -43,113 +42,163 @@ using namespace std;
 
 void ChangeObserverTest::setUp()
 {
-	m_signaler = new ChangeSignaler;
+	m_signaler = make_unique<ChangeSignaler>();
 }
 
 
 void ChangeObserverTest::tearDown()
 {
-	delete m_signaler; m_signaler = nullptr;
+	m_signaler.release();
 }
 
 
 void ChangeObserverTest::testAddObserver()
 {
-	ChangeObserver obj;
+	ChangeObserver changeObserver;
 
-	CPPUNIT_ASSERT(!m_signaler->hasObserver(&obj));
-	m_signaler->addObserver(&obj);
-	CPPUNIT_ASSERT(m_signaler->hasObserver(&obj));
-}
-
-
-static void signaler(void *aObj)
-{
-	const auto s = (ChangeSignaler *) aObj;
-	this_thread::sleep_for(1000ms);
-	s->signalObservers(100);
+	CPPUNIT_ASSERT(!m_signaler->hasObserver(&changeObserver));
+	m_signaler->addObserver(&changeObserver);
+	CPPUNIT_ASSERT(m_signaler->hasObserver(&changeObserver));
 }
 
 
 void ChangeObserverTest::testSignalObserver()
 {
-	ChangeObserver obj;
+	ChangeObserver changeObserver;
 
-	m_signaler->addObserver(&obj);
-	dlib::create_new_thread(signaler, m_signaler);
-	CPPUNIT_ASSERT(obj.wait(2000));
-	obj.reset();
+	auto const expectedExeTime = 500ms;
+	auto const expectedSeq = uint64_t{100};
+	auto threadLambda = [&expectedExeTime, &expectedSeq](ChangeSignaler* changeSignaler)
+	{
+		this_thread::sleep_for(expectedExeTime);
+		changeSignaler->signalObservers(expectedSeq);
+	};
 
-	dlib::create_new_thread(signaler, m_signaler);
-	CPPUNIT_ASSERT(!obj.wait(500));
 
-	// Wait for things to clean up...
-	this_thread::sleep_for(1000ms);
+	m_signaler->addObserver(&changeObserver);
+	CPPUNIT_ASSERT(!changeObserver.wasSignaled());
+	auto workerThread = thread{threadLambda, m_signaler.get()};
+
+	auto startTime = chrono::system_clock::now();
+	CPPUNIT_ASSERT(changeObserver.wait((expectedExeTime * 2).count())); // Wait to be signalled within twice expected time
+	
+	// The worker thread was put to sleep for 500 milli-seconds before signalling
+	// observers, so at very least the duration should be greater than 500 milli-seconds.
+	// The observer should also have received the sequence number 100
+	auto durationMs = chrono::duration_cast<chrono::milliseconds>(chrono::system_clock::now() - startTime);
+	try
+	{
+		CPPUNIT_ASSERT_GREATEREQUAL(expectedExeTime.count(), durationMs.count());
+		CPPUNIT_ASSERT_EQUAL(expectedSeq, changeObserver.getSequence());
+		CPPUNIT_ASSERT(changeObserver.wasSignaled());
+		workerThread.join();
+	}
+	catch(...)
+	{
+		workerThread.join();
+		throw;
+	}
+
+	// Run the same test again but only wait for a shorter period than the
+	// thread will take to execute. The observer should not be signalled
+	// and the call should fail.
+	changeObserver.reset();
+	CPPUNIT_ASSERT(!changeObserver.wasSignaled());
+	auto workerThread2 = thread{threadLambda, m_signaler.get()};
+	try
+	{
+		auto waitResult = changeObserver.wait((expectedExeTime / 2).count()); // Only wait a maximum of 1/2 the expected time
+
+		// We can be spuriously woken up, so check that the work was not finished
+		if(waitResult && !changeObserver.wasSignaled())
+			waitResult = false;
+
+		CPPUNIT_ASSERT(!waitResult);
+		CPPUNIT_ASSERT(!changeObserver.wasSignaled());
+		workerThread2.join();
+	}
+	catch(...)
+	{
+		workerThread2.join();
+		throw;
+	}
 }
 
 
 void ChangeObserverTest::testCleanup()
 {
-	ChangeObserver *obj = nullptr;
+	ChangeObserver *changeObserver = nullptr;
 
 	{
-		obj = new ChangeObserver;
-		m_signaler->addObserver(obj);
-		CPPUNIT_ASSERT(m_signaler->hasObserver(obj));
-		delete obj; // Not setting to nullptr so we can test observer was removed
+		changeObserver = new ChangeObserver;
+		m_signaler->addObserver(changeObserver);
+		CPPUNIT_ASSERT(m_signaler->hasObserver(changeObserver));
+		delete changeObserver; // Not setting to nullptr so we can test observer was removed
 	}
 
-	CPPUNIT_ASSERT(!m_signaler->hasObserver(obj));
-}
-
-
-static void signaler2(void *aObj)
-{
-	const auto s = (ChangeSignaler *) aObj;
-	s->signalObservers(100);
-	s->signalObservers(200);
-	s->signalObservers(300);
+	CPPUNIT_ASSERT(!m_signaler->hasObserver(changeObserver));
 }
 
 
 void ChangeObserverTest::testChangeSequence()
 {
-	ChangeObserver obj;
+	ChangeObserver changeObserver;
 
-	m_signaler->addObserver(&obj);
-	CPPUNIT_ASSERT(!obj.wasSignaled());
-	dlib::create_new_thread(signaler2, m_signaler);
-	CPPUNIT_ASSERT(obj.wait(2000));
-	CPPUNIT_ASSERT(obj.wasSignaled());
+	m_signaler->addObserver(&changeObserver);
+	CPPUNIT_ASSERT(!changeObserver.wasSignaled());
 
-	CPPUNIT_ASSERT_EQUAL((uint64_t) 100ull, obj.getSequence());
+	auto threadLambda = [](ChangeSignaler* changeSignaler)
+	{
+		changeSignaler->signalObservers(uint64_t{100});
+		changeSignaler->signalObservers(uint64_t{200});
+		changeSignaler->signalObservers(uint64_t{300});
+	};
+	auto workerThread = thread{threadLambda, m_signaler.get()};
+	try
+	{
+		CPPUNIT_ASSERT(changeObserver.wait(2000));
+		CPPUNIT_ASSERT(changeObserver.wasSignaled());
 
-	// Wait for things to clean up...
-	this_thread::sleep_for(1000ms);
-}
+		CPPUNIT_ASSERT_EQUAL(uint64_t{100}, changeObserver.getSequence());
 
-
-static void signaler3(void *aObj)
-{
-	const auto s = (ChangeSignaler *) aObj;
-	s->signalObservers(100);
-	s->signalObservers(200);
-	s->signalObservers(300);
-	s->signalObservers(30);
+		// Wait for things to clean up...
+		workerThread.join();
+	}
+	catch(...)
+	{
+		workerThread.join();
+		throw;
+	}
 }
 
 
 void ChangeObserverTest::testChangeSequence2()
 {
-	ChangeObserver obj;
+	ChangeObserver changeObserver;
 
-	m_signaler->addObserver(&obj);
-	dlib::create_new_thread(signaler3, m_signaler);
-	CPPUNIT_ASSERT(obj.wait(2000));
-	this_thread::sleep_for(500ms);
+	m_signaler->addObserver(&changeObserver);
 
-	CPPUNIT_ASSERT_EQUAL((uint64_t) 30ull, obj.getSequence());
+	auto threadLambda = [](ChangeSignaler* changeSignaler)
+	{
+		changeSignaler->signalObservers(uint64_t{100});
+		changeSignaler->signalObservers(uint64_t{200});
+		changeSignaler->signalObservers(uint64_t{300});
+		changeSignaler->signalObservers(uint64_t{30});
+	};
+	auto workerThread = thread{threadLambda, m_signaler.get()};
+	try
+	{
+		CPPUNIT_ASSERT(changeObserver.wait(2000));
+		CPPUNIT_ASSERT(changeObserver.wasSignaled());
+		this_thread::sleep_for(50ms);
+		CPPUNIT_ASSERT_EQUAL(uint64_t{30}, changeObserver.getSequence());
 
-	// Wait for things to clean up...
-	this_thread::sleep_for(1000ms);
+		// Wait for things to clean up...
+		workerThread.join();
+	}
+	catch(...)
+	{
+		workerThread.join();
+		throw;
+	}
 }

--- a/test/change_observer_test.hpp
+++ b/test/change_observer_test.hpp
@@ -35,7 +35,7 @@
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
-
+#include <memory>
 #include "change_observer.hpp"
 
 class ChangeObserverTest : public CppUnit::TestFixture
@@ -49,7 +49,7 @@ class ChangeObserverTest : public CppUnit::TestFixture
 	CPPUNIT_TEST_SUITE_END();
 
 protected:
-	ChangeSignaler *m_signaler;
+	std::unique_ptr<ChangeSignaler> m_signaler;
 
 public:
 	void testAddObserver();


### PR DESCRIPTION
* Fixed bad check due to spurious thread wake-up

* Refactored to remove dlib threads and replaced with std::thread and utilized lambda functions improving readability

* Added more assertions relating to timings

* Replaced new/delete with std::unique_ptr