### PR TITLE
Refactored memory management in tests (#12)

### DIFF
--- a/test/agent_test.cpp
+++ b/test/agent_test.cpp
@@ -53,19 +53,18 @@ using namespace std::chrono;
 void AgentTest::setUp()
 {
 	XmlPrinter::setSchemaVersion("1.3");
-	m_agent = nullptr;
-	m_agent = new Agent("../samples/test_config.xml", 8, 4, 25ms);
+	m_agent = make_unique<Agent>("../samples/test_config.xml", 8, 4, 25ms);
 	m_agentId = intToString(getCurrentTimeInSec());
 	m_adapter = nullptr;
 
-  m_agentTestHelper.m_agent = m_agent;
-  m_agentTestHelper.m_queries.clear();
+	m_agentTestHelper.m_agent = m_agent.get();
+	m_agentTestHelper.m_queries.clear();
 }
 
 
 void AgentTest::tearDown()
 {
-  delete m_agent; m_agent = nullptr;
+	m_agent.reset();
 	m_adapter = nullptr;
 }
 
@@ -690,10 +689,9 @@ void AgentTest::testAdapterCommands()
 
 void AgentTest::testAdapterDeviceCommand()
 {
-	delete m_agent; m_agent = nullptr;
-	m_agent = new Agent("../samples/two_devices.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
-  
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/two_devices.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 	m_agentTestHelper.m_path = "/probe";
 
 	auto device1 = m_agent->getDeviceByName("Device1");
@@ -1603,9 +1601,9 @@ void AgentTest::testAssetAdditionOfAssetChanged12()
 	string version = XmlPrinter::getSchemaVersion();
 	XmlPrinter::setSchemaVersion("1.2");
 
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/min_config.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/min_config.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	{
 		m_agentTestHelper.m_path = "/probe";
@@ -1623,9 +1621,9 @@ void AgentTest::testAssetAdditionOfAssetRemoved13()
 	string version = XmlPrinter::getSchemaVersion();
 	XmlPrinter::setSchemaVersion("1.3");
 
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/min_config.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/min_config.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	{
 		m_agentTestHelper.m_path = "/probe";
@@ -2137,9 +2135,9 @@ void AgentTest::testInitialTimeSeriesValues()
 
 void AgentTest::testFilterValues13()
 {
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/filter_example_1.3.xml", 8, 4, 25ms);
-	m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/filter_example_1.3.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	CPPUNIT_ASSERT(m_adapter);
@@ -2191,9 +2189,9 @@ void AgentTest::testFilterValues13()
 
 void AgentTest::testFilterValues()
 {
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/filter_example.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/filter_example.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	CPPUNIT_ASSERT(m_adapter);
@@ -2257,9 +2255,9 @@ void AgentTest::testFilterValues()
 	}
 
 	// Test period filter with ignore timestamps
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/filter_example.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/filter_example.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	m_adapter->setIgnoreTimestamps(true);
@@ -2292,9 +2290,9 @@ void AgentTest::testFilterValues()
 	}
 
 	// Test period filter with relative time
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/filter_example.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/filter_example.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	m_adapter->setRelativeTime(true);
@@ -2339,9 +2337,9 @@ void AgentTest::testResetTriggered()
 {
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	CPPUNIT_ASSERT(m_adapter);
-  
+
 	m_agentTestHelper.m_path = "/sample";
-  
+
 	m_adapter->processData("TIME1|pcount|0");
 	m_adapter->processData("TIME2|pcount|1");
 	m_adapter->processData("TIME3|pcount|2");
@@ -2364,9 +2362,9 @@ void AgentTest::testResetTriggered()
 
 void AgentTest::testReferences()
 {
-	delete m_agent; m_agent = nullptr;
-	m_agent = new Agent("../samples/reference_example.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/reference_example.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	CPPUNIT_ASSERT(m_adapter);
@@ -2380,19 +2378,19 @@ void AgentTest::testReferences()
 
 	CPPUNIT_ASSERT_EQUAL((string) "c4", ref.m_id);
 	CPPUNIT_ASSERT_EQUAL((string) "chuck", ref.m_name);
-  CPPUNIT_ASSERT_EQUAL(Component::Reference::DATA_ITEM, ref.m_type);
+	CPPUNIT_ASSERT_EQUAL(Component::Reference::DATA_ITEM, ref.m_type);
 
 	CPPUNIT_ASSERT_MESSAGE("DataItem was not resolved", ref.m_dataItem);
 
 	const Component::Reference &ref2 = refs[1];
 	CPPUNIT_ASSERT_EQUAL((string) "d2", ref2.m_id);
 	CPPUNIT_ASSERT_EQUAL((string) "door", ref2.m_name);
-  CPPUNIT_ASSERT_EQUAL(Component::Reference::DATA_ITEM, ref2.m_type);
+	CPPUNIT_ASSERT_EQUAL(Component::Reference::DATA_ITEM, ref2.m_type);
 
-  const Component::Reference &ref3 = refs[2];
-  CPPUNIT_ASSERT_EQUAL((string) "ele", ref3.m_id);
-  CPPUNIT_ASSERT_EQUAL((string) "electric", ref3.m_name);
-  CPPUNIT_ASSERT_EQUAL(Component::Reference::COMPONENT, ref3.m_type);
+	const Component::Reference &ref3 = refs[2];
+	CPPUNIT_ASSERT_EQUAL((string) "ele", ref3.m_id);
+	CPPUNIT_ASSERT_EQUAL((string) "electric", ref3.m_name);
+	CPPUNIT_ASSERT_EQUAL(Component::Reference::COMPONENT, ref3.m_type);
 
 	CPPUNIT_ASSERT_MESSAGE("DataItem was not resolved", ref3.m_component);
 
@@ -2414,9 +2412,9 @@ void AgentTest::testReferences()
 
 void AgentTest::testDiscrete()
 {
-	delete m_agent; m_agent= nullptr;
-	m_agent = new Agent("../samples/discrete_example.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/discrete_example.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
 
 	m_agentTestHelper.m_path = "/sample";
 
@@ -2466,10 +2464,10 @@ void AgentTest::testDiscrete()
 void AgentTest::testUpcaseValues()
 {
 	m_agentTestHelper.m_path = "/current";
-	delete m_agent; m_agent = nullptr;
-	m_agent = new Agent("../samples/discrete_example.xml", 8, 4, 25ms);
-  m_agentTestHelper.m_agent = m_agent;
-  
+	m_agent.reset();
+	m_agent = make_unique<Agent>("../samples/discrete_example.xml", 8, 4, 25ms);
+	m_agentTestHelper.m_agent = m_agent.get();
+
 	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
 	m_adapter->setDupCheck(true);
 	CPPUNIT_ASSERT(m_adapter);

--- a/test/agent_test.hpp
+++ b/test/agent_test.hpp
@@ -41,6 +41,7 @@
 #include <string>
 #include <iosfwd>
 #include <chrono>
+#include <memory>
 
 #include "dlib/md5.h"
 #include "dlib/server.h"
@@ -134,10 +135,10 @@ class AgentTest : public CppUnit::TestFixture
 	typedef dlib::queue<std::string>::kernel_1a_c queue_type;
 
 protected:
-	Agent *m_agent;
+	std::unique_ptr<Agent> m_agent;
 	Adapter *m_adapter;
-  std::string m_agentId;
-  AgentTestHelper m_agentTestHelper;
+	std::string m_agentId;
+	AgentTestHelper m_agentTestHelper;
 
 	std::chrono::milliseconds m_delay;
 

--- a/test/change_observer_test.cpp
+++ b/test/change_observer_test.cpp
@@ -48,7 +48,7 @@ void ChangeObserverTest::setUp()
 
 void ChangeObserverTest::tearDown()
 {
-	m_signaler.release();
+	m_signaler.reset();
 }
 
 

--- a/test/checkpoint_test.cpp
+++ b/test/checkpoint_test.cpp
@@ -43,10 +43,9 @@ void CheckpointTest::setUp()
 	// Create an agent with only 16 slots and 8 data items.
 	m_agent = nullptr;
 	m_checkpoint = nullptr;
-	m_agent = new Agent("../samples/min_config.xml", 4, 4);
+	m_agent = make_unique<Agent>("../samples/min_config.xml", 4, 4);
 	m_agentId = int64ToString(getCurrentTimeInSec());
-	m_adapter = nullptr;
-	m_checkpoint = new Checkpoint();
+	m_checkpoint = make_unique<Checkpoint>();
 
 	std::map<string, string> attributes1, attributes2;
 
@@ -54,7 +53,7 @@ void CheckpointTest::setUp()
 	attributes1["name"] = "DataItemTest1";
 	attributes1["type"] = "LOAD";
 	attributes1["category"] = "CONDITION";
-	m_dataItem1 = new DataItem(attributes1);
+	m_dataItem1 = make_unique<DataItem>(attributes1);
 
 	attributes2["id"] = "3";
 	attributes2["name"] = "DataItemTest2";
@@ -62,16 +61,16 @@ void CheckpointTest::setUp()
 	attributes2["nativeUnits"] = "MILLIMETER";
 	attributes2["subType"] = "ACTUAL";
 	attributes2["category"] = "SAMPLE";
-	m_dataItem2 = new DataItem(attributes2);
+	m_dataItem2 = make_unique<DataItem>(attributes2);
 }
 
 
 void CheckpointTest::tearDown()
 {
-	delete m_agent; m_agent = nullptr;
-	delete m_checkpoint; m_checkpoint = nullptr;
-	delete m_dataItem1; m_dataItem1 = nullptr;
-	delete m_dataItem2; m_dataItem2 = nullptr;
+	m_agent.reset();
+	m_checkpoint.reset();
+	m_dataItem1.reset();
+	m_dataItem2.reset();
 }
 
 
@@ -186,7 +185,7 @@ void CheckpointTest::testGetComponentEvents()
 	attributes["nativeUnits"] = "MILLIMETER";
 	attributes["subType"] = "ACTUAL";
 	attributes["category"] = "SAMPLE";
-	auto d1 = new DataItem(attributes);
+	auto d1 = make_unique<DataItem>(attributes);
 	filter.insert(d1->getId());
 
 	p = new ComponentEvent(*d1, 2, time, value);
@@ -206,7 +205,7 @@ void CheckpointTest::testGetComponentEvents()
 
 	CPPUNIT_ASSERT_EQUAL(2, (int) list2.size());
 
-	delete d1; d1 = nullptr;
+	d1.reset();
 }
 
 
@@ -239,7 +238,7 @@ void CheckpointTest::testFilter()
 	attributes["nativeUnits"] = "MILLIMETER";
 	attributes["subType"] = "ACTUAL";
 	attributes["category"] = "SAMPLE";
-	auto d1 = new DataItem(attributes);
+	auto d1 = make_unique<DataItem>(attributes);
 
 	p4 = new ComponentEvent(*d1, 2, time, value);
 	m_checkpoint->addComponentEvent(p4);
@@ -255,7 +254,7 @@ void CheckpointTest::testFilter()
 	m_checkpoint->getComponentEvents(list);
 
 	CPPUNIT_ASSERT_EQUAL(2, (int) list.size());
-	delete d1; d1 = nullptr;
+	d1.reset();
 }
 
 
@@ -289,7 +288,7 @@ void CheckpointTest::testCopyAndFilter()
 	attributes["nativeUnits"] = "MILLIMETER";
 	attributes["subType"] = "ACTUAL";
 	attributes["category"] = "SAMPLE";
-	auto d1 = new DataItem(attributes);
+	auto d1 = make_unique<DataItem>(attributes);
 
 	p = new ComponentEvent(*d1, 2, time, value);
 	m_checkpoint->addComponentEvent(p);
@@ -323,7 +322,7 @@ void CheckpointTest::testCopyAndFilter()
 	check.getComponentEvents(list);
 	CPPUNIT_ASSERT_EQUAL(3, (int) list.size());
 
-	delete d1; d1 = nullptr;
+	d1.reset();
 }
 
 

--- a/test/checkpoint_test.hpp
+++ b/test/checkpoint_test.hpp
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <string>
+#include <memory>
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -56,12 +57,11 @@ class CheckpointTest : public CppUnit::TestFixture
 	CPPUNIT_TEST_SUITE_END();
 
 protected:
-	Checkpoint *m_checkpoint;
-	Agent *m_agent;
-	Adapter *m_adapter;
+	std::unique_ptr<Checkpoint> m_checkpoint;
+	std::unique_ptr<Agent> m_agent;
 	std::string m_agentId;
-	DataItem *m_dataItem1;
-	DataItem *m_dataItem2;
+	std::unique_ptr<DataItem> m_dataItem1;
+	std::unique_ptr<DataItem> m_dataItem2;
 
 protected:
 	void testAddComponentEvents();

--- a/test/component_event_test.cpp
+++ b/test/component_event_test.cpp
@@ -51,7 +51,7 @@ void ComponentEventTest::setUp()
 	attributes1["name"] = "DataItemTest1";
 	attributes1["type"] = "ALARM";
 	attributes1["category"] = "EVENT";
-	m_dataItem1 = new DataItem(attributes1);
+	m_dataItem1 = make_unique<DataItem>(attributes1);
 
 	attributes2["id"] = "3";
 	attributes2["name"] = "DataItemTest2";
@@ -59,7 +59,7 @@ void ComponentEventTest::setUp()
 	attributes2["nativeUnits"] = "MILLIMETER";
 	attributes2["subType"] = "ACTUAL";
 	attributes2["category"] = "SAMPLE";
-	m_dataItem2 = new DataItem(attributes2);
+	m_dataItem2 = make_unique<DataItem>(attributes2);
 
 	string time("NOW"), value("CODE|NATIVE|CRITICAL|ACTIVE|DESCRIPTION");
 	m_compEventA = new ComponentEvent(*m_dataItem1, 2, time, value);
@@ -74,8 +74,8 @@ void ComponentEventTest::tearDown()
 {
 	m_compEventA->unrefer();
 	m_compEventB->unrefer();
-	delete m_dataItem1; m_dataItem1 = nullptr;
-	delete m_dataItem2; m_dataItem2 = nullptr;
+	m_dataItem1.reset();
+	m_dataItem2.reset();
 }
 
 
@@ -130,8 +130,8 @@ void ComponentEventTest::testGetAttributes()
 
 void ComponentEventTest::testGetters()
 {
-	CPPUNIT_ASSERT_EQUAL(m_dataItem1, m_compEventA->getDataItem());
-	CPPUNIT_ASSERT_EQUAL(m_dataItem2, m_compEventB->getDataItem());
+	CPPUNIT_ASSERT_EQUAL(m_dataItem1.get(), m_compEventA->getDataItem());
+	CPPUNIT_ASSERT_EQUAL(m_dataItem2.get(), m_compEventB->getDataItem());
 
 	CPPUNIT_ASSERT_EQUAL((string) "DESCRIPTION", m_compEventA->getValue());
 	CPPUNIT_ASSERT_EQUAL((string) "1.1231", m_compEventB->getValue());
@@ -315,7 +315,7 @@ void ComponentEventTest::testCondition()
 	attributes1["name"] = "DataItemTest1";
 	attributes1["type"] = "TEMPERATURE";
 	attributes1["category"] = "CONDITION";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	ComponentEventPtr event1(new ComponentEvent(*d, 123, time, (string) "FAULT|4321|1|HIGH|Overtemp"), true);
 
@@ -353,7 +353,7 @@ void ComponentEventTest::testCondition()
 	CPPUNIT_ASSERT_EQUAL((string) "2", attrs2["nativeSeverity"]);
 	CPPUNIT_ASSERT_EQUAL((string) "Fault", event2->getLevelString());
 
-	delete d; d = nullptr;
+	d.reset();
 }
 
 
@@ -366,7 +366,7 @@ void ComponentEventTest::testTimeSeries()
 	attributes1["type"] = "TEMPERATURE";
 	attributes1["category"] = "SAMPLE";
 	attributes1["representation"] = "TIME_SERIES";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	CPPUNIT_ASSERT(d->isTimeSeries());
 
@@ -411,7 +411,7 @@ void ComponentEventTest::testTimeSeries()
 		CPPUNIT_ASSERT_EQUAL((float)((i + 1) * 10), values[i]);
 	}
 
-	delete d; d = nullptr;
+	d.reset();
 }
 
 
@@ -424,7 +424,7 @@ void ComponentEventTest::testDuration()
 	attributes1["type"] = "TEMPERATURE";
 	attributes1["category"] = "SAMPLE";
 	attributes1["statistic"] = "AVERAGE";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	ComponentEventPtr event1(new ComponentEvent(*d, 123, time, (string) "11.0"), true);
 	const auto &attr_list = event1->getAttributes();
@@ -437,7 +437,7 @@ void ComponentEventTest::testDuration()
 	CPPUNIT_ASSERT_EQUAL((string) "2011-02-18T15:52:41Z", attrs1["timestamp"]);
 	CPPUNIT_ASSERT_EQUAL((string) "200.1232", attrs1["duration"]);
 
-	delete d; d = nullptr;
+	d.reset();
 }
 
 
@@ -449,7 +449,7 @@ void ComponentEventTest::testAssetChanged()
 	attributes1["name"] = "ac";
 	attributes1["type"] = "ASSET_CHANGED";
 	attributes1["category"] = "EVENT";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	CPPUNIT_ASSERT(d->isAssetChanged());
 
@@ -463,5 +463,5 @@ void ComponentEventTest::testAssetChanged()
 	CPPUNIT_ASSERT_EQUAL((string) "CuttingTool", attrs1["assetType"]);
 	CPPUNIT_ASSERT_EQUAL((string) "123", event1->getValue());
 
-	delete d; d = nullptr;
+	d.reset();
 }

--- a/test/component_event_test.hpp
+++ b/test/component_event_test.hpp
@@ -35,6 +35,7 @@
 
 #include <map>
 #include <string>
+#include <memory>
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -65,8 +66,8 @@ public:
 protected:
 	ComponentEvent *m_compEventA;
 	ComponentEvent *m_compEventB;
-	DataItem *m_dataItem1;
-	DataItem *m_dataItem2;
+	std::unique_ptr<DataItem> m_dataItem1;
+	std::unique_ptr<DataItem> m_dataItem2;
 
 protected:
 	void testConstructors();

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -54,13 +54,13 @@ using namespace std::chrono;
 
 void ConfigTest::setUp()
 {
-	m_config = new AgentConfiguration();
+	m_config = make_unique<AgentConfiguration>();
 }
 
 
 void ConfigTest::tearDown()
 {
-	delete m_config; m_config = nullptr;
+	m_config.reset();
 }
 
 
@@ -469,10 +469,10 @@ void ConfigTest::testMaxSize()
 		"}\n");
 	m_config->loadConfig(logger);
 	auto fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(150ull, fl->getMaxSize());
-	delete m_config; m_config = nullptr;
+	CPPUNIT_ASSERT_EQUAL(150ui64, fl->getMaxSize());
+	m_config.reset();
 
-	m_config = new AgentConfiguration();
+	m_config = make_unique<AgentConfiguration>();
 	istringstream logger2(
 		"logger_config {"
 		"max_size = 15K\n"
@@ -480,10 +480,10 @@ void ConfigTest::testMaxSize()
 	m_config->loadConfig(logger2);
 
 	fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(15ull * 1024ull, fl->getMaxSize());
-	delete m_config; m_config = nullptr;
+	CPPUNIT_ASSERT_EQUAL(15ui64 * 1024ui64, fl->getMaxSize());
+	m_config.reset();
 
-	m_config = new AgentConfiguration();
+	m_config = make_unique<AgentConfiguration>();
 	istringstream logger3(
 		"logger_config {"
 		"max_size = 15M\n"
@@ -491,10 +491,10 @@ void ConfigTest::testMaxSize()
 	m_config->loadConfig(logger3);
 
 	fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(15ull * 1024ull * 1024ull, fl->getMaxSize());
-	delete m_config; m_config = nullptr;
+	CPPUNIT_ASSERT_EQUAL(15ui64 * 1024ui64 * 1024ui64, fl->getMaxSize());
+	m_config.reset();
 
-	m_config = new AgentConfiguration();
+	m_config = make_unique<AgentConfiguration>();
 	istringstream logger4(
 		"logger_config {"
 		"max_size = 15G\n"
@@ -502,6 +502,6 @@ void ConfigTest::testMaxSize()
 	m_config->loadConfig(logger4);
 
 	fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(15ull * 1024ull * 1024ull * 1024ull, fl->getMaxSize());
+	CPPUNIT_ASSERT_EQUAL(15ui64 * 1024ui64 * 1024ui64 * 1024ui64, fl->getMaxSize());
 
 }

--- a/test/config_test.hpp
+++ b/test/config_test.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <memory>
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -66,7 +67,7 @@ public:
 	void tearDown();
 
 protected:
-	AgentConfiguration *m_config;
+	std::unique_ptr<AgentConfiguration> m_config;
 
 protected:
 	void testBlankConfig();

--- a/test/data_item_test.cpp
+++ b/test/data_item_test.cpp
@@ -49,7 +49,7 @@ void DataItemTest::setUp()
 	attributes1["type"] = "ACCELERATION";
 	attributes1["category"] = "SAMPLE";
 	attributes1["nativeUnits"] = "PERCENT";
-	m_dataItemA = new DataItem(attributes1);
+	m_dataItemA = make_unique<DataItem>(attributes1);
 
 	attributes2["id"] = "3";
 	attributes2["name"] = "DataItemTest2";
@@ -60,21 +60,21 @@ void DataItemTest::setUp()
 	attributes2["nativeScale"] = "1.0";
 	attributes2["significantDigits"] = "1";
 	attributes2["coordinateSystem"] = "testCoordinateSystem";
-	m_dataItemB = new DataItem(attributes2);
+	m_dataItemB = make_unique<DataItem>(attributes2);
 
 	attributes3["id"] = "4";
 	attributes3["name"] = "DataItemTest3";
 	attributes3["type"] = "LOAD";
 	attributes3["category"] = "CONDITION";
-	m_dataItemC = new DataItem(attributes3);
+	m_dataItemC = make_unique<DataItem>(attributes3);
 }
 
 
 void DataItemTest::tearDown()
 {
-	delete m_dataItemA; m_dataItemA = nullptr;
-	delete m_dataItemB; m_dataItemB = nullptr;
-	delete m_dataItemC; m_dataItemC = nullptr;
+	m_dataItemA.reset();
+	m_dataItemB.reset();
+	m_dataItemC.reset();
 }
 
 
@@ -265,10 +265,10 @@ void DataItemTest::testTimeSeries()
 	attributes1["units"] = "MILLIMETER";
 	attributes1["nativeUnits"] = "MILLIMETER";
 	attributes1["representation"] = "TIME_SERIES";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	CPPUNIT_ASSERT_EQUAL(string("PositionTimeSeries"), d->getElementName());
-	delete d; d = nullptr;
+	d.reset();
 
 	attributes1.clear();
 	attributes1["id"] = "1";
@@ -278,10 +278,10 @@ void DataItemTest::testTimeSeries()
 	attributes1["units"] = "MILLIMETER";
 	attributes1["nativeUnits"] = "MILLIMETER";
 	attributes1["representation"] = "VALUE";
-	d = new DataItem(attributes1);
+	d = make_unique<DataItem>(attributes1);
 
 	CPPUNIT_ASSERT_EQUAL(string("Position"), d->getElementName());
-	delete d; d = nullptr;
+	d.reset();
 }
 
 
@@ -296,10 +296,10 @@ void DataItemTest::testStatistic()
 	attributes1["units"] = "MILLIMETER";
 	attributes1["nativeUnits"] = "MILLIMETER";
 	attributes1["statistic"] = "AVERAGE";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	CPPUNIT_ASSERT_EQUAL(string("AVERAGE"), d->getStatistic());
-	delete d; d = nullptr;
+	d.reset();
 }
 
 
@@ -316,10 +316,10 @@ void DataItemTest::testSampleRate()
 	attributes1["statistic"] = "AVERAGE";
 	attributes1["representation"] = "TIME_SERIES";
 	attributes1["sampleRate"] = "42000";
-	auto d = new DataItem(attributes1);
+	auto d = make_unique<DataItem>(attributes1);
 
 	CPPUNIT_ASSERT_EQUAL(string("42000"), d->getSampleRate());
-	delete d; d = nullptr;
+	d.reset();
 }
 
 

--- a/test/data_item_test.hpp
+++ b/test/data_item_test.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -57,9 +59,9 @@ class DataItemTest : public CppUnit::TestFixture
 	CPPUNIT_TEST_SUITE_END();
 
 protected:
-	DataItem *m_dataItemA;
-	DataItem *m_dataItemB;
-	DataItem *m_dataItemC;
+	std::unique_ptr<DataItem> m_dataItemA;
+	std::unique_ptr<DataItem> m_dataItemB;
+	std::unique_ptr<DataItem> m_dataItemC;
 
 protected:
 	void testGetters();

--- a/test/data_set_test.cpp
+++ b/test/data_set_test.cpp
@@ -24,490 +24,472 @@ using namespace std;
 
 void DataSetTest::setUp()
 {
-  // Create an agent with only 16 slots and 8 data items.
-  m_agent = nullptr;
-  m_checkpoint = nullptr;
-  m_agent = new Agent("../samples/data_set.xml", 4, 4);
-  m_agentId = int64ToString(getCurrentTimeInSec());
-  m_adapter = nullptr;
-  m_checkpoint = new Checkpoint();
-  m_agentTestHelper.m_agent = m_agent;
-  
-  std::map<string, string> attributes;
-  auto device = m_agent->getDeviceByName("LinuxCNC");
-  m_dataItem1 = device->getDeviceDataItem("v1");
+	// Create an agent with only 16 slots and 8 data items.
+	m_checkpoint = nullptr;
+	m_agent = make_unique<Agent>("../samples/data_set.xml", 4, 4);
+	m_agentId = int64ToString(getCurrentTimeInSec());
+	m_adapter = nullptr;
+	m_checkpoint = make_unique<Checkpoint>();
+	m_agentTestHelper.m_agent = m_agent.get();
+
+	std::map<string, string> attributes;
+	auto device = m_agent->getDeviceByName("LinuxCNC");
+	m_dataItem1 = device->getDeviceDataItem("v1");
 }
 
 
 void DataSetTest::tearDown()
 {
-  if (m_agent != nullptr) {
-    delete m_agent; m_agent = nullptr;
-  }
-  if (m_checkpoint != nullptr) {
-    delete m_checkpoint; m_checkpoint = nullptr;
-  }
-  if (m_dataItem1 != nullptr) {
-    delete m_dataItem1; m_dataItem1 = nullptr;
-  }
+	m_agent.reset();
+	m_checkpoint.reset();
+	if(m_dataItem1)
+	{
+		delete m_dataItem1;
+		m_dataItem1 = nullptr;
+	}
 }
 
 void DataSetTest::testDataItem()
 {
-  CPPUNIT_ASSERT(m_dataItem1->isDataSet());
-  auto &attrs = m_dataItem1->getAttributes();
-  
-  CPPUNIT_ASSERT_EQUAL((string) "DATA_SET", attrs.at("representation"));
-  CPPUNIT_ASSERT_EQUAL((string) "VariableDataSet", m_dataItem1->getElementName());
+	CPPUNIT_ASSERT(m_dataItem1->isDataSet());
+	auto &attrs = m_dataItem1->getAttributes();
+
+	CPPUNIT_ASSERT_EQUAL((string) "DATA_SET", attrs.at("representation"));
+	CPPUNIT_ASSERT_EQUAL((string) "VariableDataSet", m_dataItem1->getElementName());
 }
 
 void DataSetTest::testInitialSet()
 {
-  string value("a:1 b:2 c:3 d:4");
-  auto ce = new ComponentEvent(*m_dataItem1, 2, "time", value);
-  
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, ce->getDataSet().size());
-  auto &al = ce->getAttributes();
-  std::map<string, string> attrs;
-  
-  for (const auto &attr : al)
-    attrs[attr.first] = attr.second;
+	string value("a:1 b:2 c:3 d:4");
+	auto ce = new ComponentEvent(*m_dataItem1, 2, "time", value);
 
-  CPPUNIT_ASSERT_EQUAL((string) "4", attrs.at("sampleCount"));
-  
-  auto map1 = ce->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "1", map1.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "3", map1.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, ce->getDataSet().size());
+	auto &al = ce->getAttributes();
+	std::map<string, string> attrs;
 
-  m_checkpoint->addComponentEvent(ce);
-  auto c2 = *m_checkpoint->getEventPtr("v1");
-  auto al2 = c2->getAttributes();
-  
-  attrs.clear();
-  for (const auto &attr : al2)
-    attrs[attr.first] = attr.second;
+	for (const auto &attr : al)
+		attrs[attr.first] = attr.second;
 
-  CPPUNIT_ASSERT_EQUAL((string) "4", attrs.at("sampleCount"));
-  
-  auto map2 = c2->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "1", map2.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "2", map2.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "3", map2.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map2.at("d"));
-  
-  ce->unrefer();
+	CPPUNIT_ASSERT_EQUAL((string) "4", attrs.at("sampleCount"));
+
+	auto map1 = ce->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "1", map1.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "3", map1.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
+
+	m_checkpoint->addComponentEvent(ce);
+	auto c2 = *m_checkpoint->getEventPtr("v1");
+	auto al2 = c2->getAttributes();
+
+	attrs.clear();
+	for (const auto &attr : al2)
+		attrs[attr.first] = attr.second;
+
+	CPPUNIT_ASSERT_EQUAL((string) "4", attrs.at("sampleCount"));
+
+	auto map2 = c2->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "1", map2.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "2", map2.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "3", map2.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map2.at("d"));
+
+	ce->unrefer();
 }
 
 void DataSetTest::testUpdateOneElement()
 {
-  string value("a:1 b:2 c:3 d:4");
-  ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
-  m_checkpoint->addComponentEvent(ce);
+	string value("a:1 b:2 c:3 d:4");
+	ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
+	m_checkpoint->addComponentEvent(ce);
 
-  auto cecp = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
+	auto cecp = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
 
-  string value2("c:5");
-  ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 2, "time", value2));
-  m_checkpoint->addComponentEvent(ce2);
+	string value2("c:5");
+	ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 2, "time", value2));
+	m_checkpoint->addComponentEvent(ce2);
 
-  auto ce3 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, ce3->getDataSet().size());
+	auto ce3 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, ce3->getDataSet().size());
 
-  auto map1 = ce3->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "1", map1.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "5", map1.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
-  
-  string value3("e:6");
-  ComponentEventPtr ce4(new ComponentEvent(*m_dataItem1, 2, "time", value3));
-  m_checkpoint->addComponentEvent(ce4);
-  
-  auto ce5 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 5, ce5->getDataSet().size());
-  
-  auto map2 = ce5->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "1", map2.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "2", map2.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "5", map2.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map2.at("d"));
-  CPPUNIT_ASSERT_EQUAL((string) "6", map2.at("e"));
+	auto map1 = ce3->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "1", map1.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "5", map1.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
+
+	string value3("e:6");
+	ComponentEventPtr ce4(new ComponentEvent(*m_dataItem1, 2, "time", value3));
+	m_checkpoint->addComponentEvent(ce4);
+
+	auto ce5 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 5, ce5->getDataSet().size());
+
+	auto map2 = ce5->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "1", map2.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "2", map2.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "5", map2.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map2.at("d"));
+	CPPUNIT_ASSERT_EQUAL((string) "6", map2.at("e"));
 }
 
 void DataSetTest::testUpdateMany()
 {
-  string value("a:1 b:2 c:3 d:4");
-  ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
-  m_checkpoint->addComponentEvent(ce);
-  
-  auto cecp = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
-  
-  string value2("c:5 e:6");
-  ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 2, "time", value2));
-  m_checkpoint->addComponentEvent(ce2);
-  
-  auto ce3 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 5, ce3->getDataSet().size());
-  
-  auto map1 = ce3->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "1", map1.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "5", map1.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
-  CPPUNIT_ASSERT_EQUAL((string) "6", map1.at("e"));
+	string value("a:1 b:2 c:3 d:4");
+	ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
+	m_checkpoint->addComponentEvent(ce);
 
-  string value3("e:7 a:8 f:9");
-  ComponentEventPtr ce4(new ComponentEvent(*m_dataItem1, 2, "time", value3));
-  m_checkpoint->addComponentEvent(ce4);
-  
-  auto ce5 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 6, ce5->getDataSet().size());
-  
-  auto map2 = ce5->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "8", map2.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "2", map2.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "5", map2.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map2.at("d"));
-  CPPUNIT_ASSERT_EQUAL((string) "7", map2.at("e"));
-  CPPUNIT_ASSERT_EQUAL((string) "9", map2.at("f"));
+	auto cecp = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
+
+	string value2("c:5 e:6");
+	ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 2, "time", value2));
+	m_checkpoint->addComponentEvent(ce2);
+
+	auto ce3 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 5, ce3->getDataSet().size());
+
+	auto map1 = ce3->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "1", map1.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "5", map1.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
+	CPPUNIT_ASSERT_EQUAL((string) "6", map1.at("e"));
+
+	string value3("e:7 a:8 f:9");
+	ComponentEventPtr ce4(new ComponentEvent(*m_dataItem1, 2, "time", value3));
+	m_checkpoint->addComponentEvent(ce4);
+
+	auto ce5 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 6, ce5->getDataSet().size());
+
+	auto map2 = ce5->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "8", map2.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "2", map2.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "5", map2.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map2.at("d"));
+	CPPUNIT_ASSERT_EQUAL((string) "7", map2.at("e"));
+	CPPUNIT_ASSERT_EQUAL((string) "9", map2.at("f"));
 }
 
 void DataSetTest::testReset()
 {
-  string value("a:1 b:2 c:3 d:4");
-  ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
-  m_checkpoint->addComponentEvent(ce);
-  
-  auto cecp = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
-  
-  string value2("RESET|c:5 e:6");
-  ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 2, "time", value2));
-  m_checkpoint->addComponentEvent(ce2);
-  
-  auto ce3 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 2, ce3->getDataSet().size());
-  
-  auto map1 = ce3->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "5", map1.at("c"));
-  CPPUNIT_ASSERT_EQUAL((string) "6", map1.at("e"));
-  
-  string value3("x:pop y:hop");
-  ComponentEventPtr ce4(new ComponentEvent(*m_dataItem1, 2, "time", value3));
-  m_checkpoint->addComponentEvent(ce4);
-  
-  auto ce5 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, ce5->getDataSet().size());
-  
-  auto map2 = ce5->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "pop", map2.at("x"));
-  CPPUNIT_ASSERT_EQUAL((string) "hop", map2.at("y"));
+	string value("a:1 b:2 c:3 d:4");
+	ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
+	m_checkpoint->addComponentEvent(ce);
+
+	auto cecp = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
+
+	string value2("RESET|c:5 e:6");
+	ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 2, "time", value2));
+	m_checkpoint->addComponentEvent(ce2);
+
+	auto ce3 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 2, ce3->getDataSet().size());
+
+	auto map1 = ce3->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "5", map1.at("c"));
+	CPPUNIT_ASSERT_EQUAL((string) "6", map1.at("e"));
+
+	string value3("x:pop y:hop");
+	ComponentEventPtr ce4(new ComponentEvent(*m_dataItem1, 2, "time", value3));
+	m_checkpoint->addComponentEvent(ce4);
+
+	auto ce5 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, ce5->getDataSet().size());
+
+	auto map2 = ce5->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "pop", map2.at("x"));
+	CPPUNIT_ASSERT_EQUAL((string) "hop", map2.at("y"));
 }
 
 void DataSetTest::testBadData()
 {
-  string value("12356");
-  auto ce = new ComponentEvent(*m_dataItem1, 2, "time", value);
-  
-  CPPUNIT_ASSERT_EQUAL((size_t) 1, ce->getDataSet().size());
-  
-  string value1("  a:2      b3:xxx");
-  auto ce2 = new ComponentEvent(*m_dataItem1, 2, "time", value1);
-  
-  CPPUNIT_ASSERT_EQUAL((size_t) 2, ce2->getDataSet().size());
-  
-  auto map1 = ce2->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("a"));
-  CPPUNIT_ASSERT_EQUAL((string) "xxx", map1.at("b3"));
+	string value("12356");
+	auto ce = new ComponentEvent(*m_dataItem1, 2, "time", value);
+
+	CPPUNIT_ASSERT_EQUAL((size_t) 1, ce->getDataSet().size());
+
+	string value1("  a:2      b3:xxx");
+	auto ce2 = new ComponentEvent(*m_dataItem1, 2, "time", value1);
+
+	CPPUNIT_ASSERT_EQUAL((size_t) 2, ce2->getDataSet().size());
+
+	auto map1 = ce2->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("a"));
+	CPPUNIT_ASSERT_EQUAL((string) "xxx", map1.at("b3"));
 }
 
 void DataSetTest::testCurrent()
 {
-  m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
-  CPPUNIT_ASSERT(m_adapter);
-  
-  m_agentTestHelper.m_path = "/current";
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
-                                      "//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
-                                      "UNAVAILABLE");
-  }
-  
-  m_adapter->processData("TIME|vars|a:1 b:2 c:3");
+	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
+	CPPUNIT_ASSERT(m_adapter);
 
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
-                                      "//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
-                                      "a:1 b:2 c:3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "3");
-}
+	m_agentTestHelper.m_path = "/current";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
+									"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
+									"UNAVAILABLE");
+	}
 
-  m_adapter->processData("TIME|vars|c:6");
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
-                                      "//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
-                                      "a:1 b:2 c:6");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "3");
-  }
+	m_adapter->processData("TIME|vars|a:1 b:2 c:3");
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
+										"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
+										"a:1 b:2 c:3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "3");
+	}
 
-  m_adapter->processData("TIME|vars|RESET|d:10");
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
-                                      "//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
-                                      "d:10");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
-                                      "//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@resetTriggered",
-                                      "RESET");
+	m_adapter->processData("TIME|vars|c:6");
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
+										"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
+										"a:1 b:2 c:6");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "3");
+	}
 
-  }
-  
-  m_adapter->processData("TIME|vars|c:6");
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
-                                      "//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
-                                      "c:6 d:10");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "2");
-  }
+	m_adapter->processData("TIME|vars|RESET|d:10");
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
+										"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
+										"d:10");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
+										"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@resetTriggered",
+										"RESET");
+
+	}
+
+	m_adapter->processData("TIME|vars|c:6");
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,
+										"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']",
+										"c:6 d:10");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc,"//m:DeviceStream//m:VariableDataSet[@dataItemId='v1']@sampleCount", "2");
+	}
 }
 
 void DataSetTest::testSample()
 {
-  m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
-  CPPUNIT_ASSERT(m_adapter);
-  
-  m_adapter->processData("TIME|vars|a:1 b:2 c:3");
-  m_adapter->processData("TIME|vars|c:5");
-  m_adapter->processData("TIME|vars|c:8");
+	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
+	CPPUNIT_ASSERT(m_adapter);
 
-  m_agentTestHelper.m_path = "/sample";
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "c:5");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "c:8");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "1");
-  }
+	m_adapter->processData("TIME|vars|a:1 b:2 c:3");
+	m_adapter->processData("TIME|vars|c:5");
+	m_adapter->processData("TIME|vars|c:8");
 
-  m_agentTestHelper.m_path = "/current";
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:8");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "3");
-  }
-  
-  m_agentTestHelper.m_path = "/sample";
-  m_adapter->processData("TIME|vars|c b:5");
+	m_agentTestHelper.m_path = "/sample";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "c:5");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "c:8");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "1");
+	}
 
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "c:5");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "c:8");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]", "b:5 c:");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@sampleCount", "2");
-  }
+	m_agentTestHelper.m_path = "/current";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:8");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "3");
+	}
 
-  m_agentTestHelper.m_path = "/current";
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:5");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "2");
-  }
-  
+	m_agentTestHelper.m_path = "/sample";
+	m_adapter->processData("TIME|vars|c b:5");
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "c:5");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "c:8");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]", "b:5 c:");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@sampleCount", "2");
+	}
+
+	m_agentTestHelper.m_path = "/current";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:5");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "2");
+	}
+
 }
 
 void DataSetTest::testCurrentAt()
 {
-  m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
-  CPPUNIT_ASSERT(m_adapter);
-  
-  auto seq = m_agent->getSequence();
-  
-  m_adapter->processData("TIME|vars|a:1 b:2 c:3");
-  m_adapter->processData("TIME|vars| c:5 ");
-  m_adapter->processData("TIME|vars|c:8");
-  m_adapter->processData("TIME|vars|b:10   a:xxx");
-  m_adapter->processData("TIME|vars|RESET|q:hello_there");
-  m_adapter->processData("TIME|vars|r:good_bye");
+	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
+	CPPUNIT_ASSERT(m_adapter);
 
-  m_agentTestHelper.m_path = "/current";
+	auto seq = m_agent->getSequence();
 
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq - 1));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
-  }
+	m_adapter->processData("TIME|vars|a:1 b:2 c:3");
+	m_adapter->processData("TIME|vars| c:5 ");
+	m_adapter->processData("TIME|vars|c:8");
+	m_adapter->processData("TIME|vars|b:10   a:xxx");
+	m_adapter->processData("TIME|vars|RESET|q:hello_there");
+	m_adapter->processData("TIME|vars|r:good_bye");
 
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:3");
-  }
-  
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 1));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:5");
-  }
+	m_agentTestHelper.m_path = "/current";
 
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 2));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:8");
-  }
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq - 1));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
+	}
 
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 3));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:xxx b:10 c:8");
-  }
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:3");
+	}
 
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 4));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "q:hello_there");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "///m:VariableDataSet@resetTriggered",
-                                      "RESET");
-  }
-  
-  {
-    PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 5));
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "q:hello_there r:good_bye");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@resetTriggered", 0);
-  }
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "q:hello_there r:good_bye");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@resetTriggered", 0);
-  }
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 1));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:5");
+	}
+
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 2));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:2 c:8");
+	}
+
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 3));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:xxx b:10 c:8");
+	}
+
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 4));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "q:hello_there");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "///m:VariableDataSet@resetTriggered",
+											"RESET");
+	}
+
+	{
+		PARSE_XML_RESPONSE_QUERY_KV("at", int64ToString(seq + 5));
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "q:hello_there r:good_bye");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@resetTriggered", 0);
+	}
+
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "q:hello_there r:good_bye");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@resetTriggered", 0);
+	}
 }
 
 void DataSetTest::testDeleteKey()
 {
-  string value("a:1 b:2 c:3 d:4");
-  ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
-  m_checkpoint->addComponentEvent(ce);
-  
-  auto cecp = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
-  
-  string value2("c e:6 a:");
-  ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 4, "time", value2));
-  m_checkpoint->addComponentEvent(ce2);
-  
-  auto ce3 = *m_checkpoint->getEventPtr("v1");
-  CPPUNIT_ASSERT_EQUAL((size_t) 3, ce3->getDataSet().size());
-  
-  auto map1 = ce3->getDataSet();
-  CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
-  CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
-  CPPUNIT_ASSERT_EQUAL((string) "6", map1.at("e"));
-  CPPUNIT_ASSERT(map1.find("c") == map1.end());
-  CPPUNIT_ASSERT(map1.find("a") == map1.end());
+	string value("a:1 b:2 c:3 d:4");
+	ComponentEventPtr ce(new ComponentEvent(*m_dataItem1, 2, "time", value));
+	m_checkpoint->addComponentEvent(ce);
+
+	auto cecp = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 4, cecp->getDataSet().size());
+
+	string value2("c e:6 a:");
+	ComponentEventPtr ce2(new ComponentEvent(*m_dataItem1, 4, "time", value2));
+	m_checkpoint->addComponentEvent(ce2);
+
+	auto ce3 = *m_checkpoint->getEventPtr("v1");
+	CPPUNIT_ASSERT_EQUAL((size_t) 3, ce3->getDataSet().size());
+
+	auto map1 = ce3->getDataSet();
+	CPPUNIT_ASSERT_EQUAL((string) "2", map1.at("b"));
+	CPPUNIT_ASSERT_EQUAL((string) "4", map1.at("d"));
+	CPPUNIT_ASSERT_EQUAL((string) "6", map1.at("e"));
+	CPPUNIT_ASSERT(map1.find("c") == map1.end());
+	CPPUNIT_ASSERT(map1.find("a") == map1.end());
 }
 
 void DataSetTest::testResetWithNoItems()
 {
-  m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
-  CPPUNIT_ASSERT(m_adapter);
-  
-  m_adapter->processData("TIME|vars|a:1 b:2 c:3");
-  m_adapter->processData("TIME|vars| c:5 ");
-  m_adapter->processData("TIME|vars|c:8");
-  m_adapter->processData("TIME|vars|b:10   a:xxx");
-  m_adapter->processData("TIME|vars|RESET|");
-  m_adapter->processData("TIME|vars|r:good_bye");
-  
-  m_agentTestHelper.m_path = "/sample";
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "c:5");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "c:8");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]", "a:xxx b:10");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@sampleCount", "2");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[6]", "");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[6]@sampleCount", "0");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[7]", "r:good_bye");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[7]@sampleCount", "1");
-  }
+	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
+	CPPUNIT_ASSERT(m_adapter);
 
+	m_adapter->processData("TIME|vars|a:1 b:2 c:3");
+	m_adapter->processData("TIME|vars| c:5 ");
+	m_adapter->processData("TIME|vars|c:8");
+	m_adapter->processData("TIME|vars|b:10   a:xxx");
+	m_adapter->processData("TIME|vars|RESET|");
+	m_adapter->processData("TIME|vars|r:good_bye");
+
+	m_agentTestHelper.m_path = "/sample";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "c:5");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "c:8");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]", "a:xxx b:10");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@sampleCount", "2");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[6]", "");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[6]@sampleCount", "0");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[7]", "r:good_bye");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[7]@sampleCount", "1");
+	}
 }
 
 void DataSetTest::testDuplicateCompression()
 {
-  m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
-  CPPUNIT_ASSERT(m_adapter);
-  
-  m_adapter->processData("TIME|vars|a:1 b:2 c:3");
-  m_adapter->processData("TIME|vars|b:2");
-  m_adapter->processData("TIME|vars|b:2 d:4");
-  m_adapter->processData("TIME|vars|b:2 d:4 c:3");
-  m_adapter->processData("TIME|vars|b:2 d:4 c:3");
-  m_adapter->processData("TIME|vars|b:3 e:4");
+	m_adapter = m_agent->addAdapter("LinuxCNC", "server", 7878, false);
+	CPPUNIT_ASSERT(m_adapter);
 
-  m_agentTestHelper.m_path = "/sample";
+	m_adapter->processData("TIME|vars|a:1 b:2 c:3");
+	m_adapter->processData("TIME|vars|b:2");
+	m_adapter->processData("TIME|vars|b:2 d:4");
+	m_adapter->processData("TIME|vars|b:2 d:4 c:3");
+	m_adapter->processData("TIME|vars|b:2 d:4 c:3");
+	m_adapter->processData("TIME|vars|b:3 e:4");
 
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "d:4");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "b:3 e:4");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "2");
-  }
-  
-  m_agentTestHelper.m_path = "/current";
+	m_agentTestHelper.m_path = "/sample";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "UNAVAILABLE");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]", "a:1 b:2 c:3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[2]@sampleCount", "3");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]", "d:4");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[3]@sampleCount", "1");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]", "b:3 e:4");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[4]@sampleCount", "2");
+	}
 
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:3 c:3 d:4 e:4");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "5");
-  }
+	m_agentTestHelper.m_path = "/current";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:3 c:3 d:4 e:4");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "5");
+	}
 
-  m_adapter->processData("TIME|vars|RESET|a:1 b:3 c:3 d:4 e:4");
-  
-  m_agentTestHelper.m_path = "/sample";
+	m_adapter->processData("TIME|vars|RESET|a:1 b:3 c:3 d:4 e:4");
 
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]", "a:1 b:3 c:3 d:4 e:4");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@sampleCount", "5");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@resetTriggered", "RESET");
+	m_agentTestHelper.m_path = "/sample";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]", "a:1 b:3 c:3 d:4 e:4");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@sampleCount", "5");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[5]@resetTriggered", "RESET");
+	}
 
-  }
-  
-  m_agentTestHelper.m_path = "/current";
-  
-  {
-    PARSE_XML_RESPONSE;
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:3 c:3 d:4 e:4");
-    CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "5");
-  }
+	m_agentTestHelper.m_path = "/current";
+	{
+		PARSE_XML_RESPONSE;
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]", "a:1 b:3 c:3 d:4 e:4");
+		CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:VariableDataSet[1]@sampleCount", "5");
+	}
 
 }

--- a/test/data_set_test.hpp
+++ b/test/data_set_test.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <iosfwd>
 #include <chrono>
+#include <memory>
 
 #include "dlib/md5.h"
 #include "dlib/server.h"
@@ -36,47 +37,47 @@
 
 class DataSetTest : public CppUnit::TestFixture
 {
-  CPPUNIT_TEST_SUITE(DataSetTest);
+	CPPUNIT_TEST_SUITE(DataSetTest);
 
-  CPPUNIT_TEST(testDataItem);
-  CPPUNIT_TEST(testInitialSet);
-  CPPUNIT_TEST(testUpdateOneElement);
-  CPPUNIT_TEST(testUpdateMany);
-  CPPUNIT_TEST(testReset);
-  CPPUNIT_TEST(testBadData);
-  CPPUNIT_TEST(testCurrent);
-  CPPUNIT_TEST(testSample);
-  CPPUNIT_TEST(testCurrentAt);
-  CPPUNIT_TEST(testDeleteKey);
-  CPPUNIT_TEST(testResetWithNoItems);
-  CPPUNIT_TEST(testDuplicateCompression);
+	CPPUNIT_TEST(testDataItem);
+	CPPUNIT_TEST(testInitialSet);
+	CPPUNIT_TEST(testUpdateOneElement);
+	CPPUNIT_TEST(testUpdateMany);
+	CPPUNIT_TEST(testReset);
+	CPPUNIT_TEST(testBadData);
+	CPPUNIT_TEST(testCurrent);
+	CPPUNIT_TEST(testSample);
+	CPPUNIT_TEST(testCurrentAt);
+	CPPUNIT_TEST(testDeleteKey);
+	CPPUNIT_TEST(testResetWithNoItems);
+	CPPUNIT_TEST(testDuplicateCompression);
 
-  CPPUNIT_TEST_SUITE_END();
-    
+	CPPUNIT_TEST_SUITE_END();
+
 protected:
-  Checkpoint *m_checkpoint;
-  Agent *m_agent;
-  Adapter *m_adapter;
-  std::string m_agentId;
-  DataItem *m_dataItem1;
-  
-  AgentTestHelper m_agentTestHelper;
-  
+	std::unique_ptr<Checkpoint> m_checkpoint;
+	std::unique_ptr<Agent> m_agent;
+	Adapter *m_adapter;
+	std::string m_agentId;
+	DataItem* m_dataItem1;
+
+	AgentTestHelper m_agentTestHelper;
+
 protected:
-  void testDataItem();
-  void testInitialSet();
-  void testUpdateOneElement();
-  void testUpdateMany();
-  void testReset();
-  void testBadData();
-  void testCurrent();
-  void testSample();
-  void testCurrentAt();
-  void testDeleteKey();
-  void testResetWithNoItems();
-  void testDuplicateCompression();
+	void testDataItem();
+	void testInitialSet();
+	void testUpdateOneElement();
+	void testUpdateMany();
+	void testReset();
+	void testBadData();
+	void testCurrent();
+	void testSample();
+	void testCurrentAt();
+	void testDeleteKey();
+	void testResetWithNoItems();
+	void testDuplicateCompression();
 
 public:
-  void setUp();
-  void tearDown();
+	void setUp();
+	void tearDown();
 };


### PR DESCRIPTION
* Replaced several instances of objects being allocated on the heap with
 new and converted to std:unique_ptr