### PR TITLE
Refactored storage for checkpoints (#16)

### DIFF
--- a/agent/agent.cpp
+++ b/agent/agent.cpp
@@ -103,7 +103,9 @@ Agent::Agent(
 	m_maxAssets = maxAssets;
 
 	// Create the checkpoints at a regular frequency
-	m_checkpoints = new Checkpoint[m_checkpointCount];
+	m_checkpoints.reserve(m_checkpointCount);
+	for(auto i = 0; i < m_checkpointCount; i++)
+		m_checkpoints.emplace_back();
 
 	// Add the devices to the device map and create availability and 
 	// asset changed events if they don't exist
@@ -246,7 +248,7 @@ Agent::~Agent()
 {
 	m_slidingBuffer.reset();
 	m_xmlParser.reset();
-	delete[] m_checkpoints; m_checkpoints = nullptr;
+	m_checkpoints.clear();
 }
 
 

--- a/agent/agent.hpp
+++ b/agent/agent.hpp
@@ -379,7 +379,7 @@ protected:
 	// Checkpoints
 	Checkpoint m_latest;
 	Checkpoint m_first;
-	Checkpoint *m_checkpoints;
+	std::vector<Checkpoint> m_checkpoints;
 
 	int m_checkpointFreq;
 	int m_checkpointCount;


### PR DESCRIPTION
* Stored checkpoints with a `std::vector` rather than a raw array allocated on the heap