### PR TITLE
Compilation issue on Alpine 97

### DIFF
--- a/cmake/DLib.cmake
+++ b/cmake/DLib.cmake
@@ -100,14 +100,27 @@ if(NOT TARGET dlib::dlib)
   message(STATUS "  * Create targets for dlib library")
   add_library(dlib::dlib STATIC IMPORTED)
 
-  set_target_properties(dlib::dlib PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/install/dlib/lib/${CMAKE_STATIC_LIBRARY_PREFIX}dlib${CMAKE_STATIC_LIBRARY_SUFFIX}"
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/install/dlib/include"
-    )
-
-  if(MSVC)
+  if(EXISTS "${CMAKE_BINARY_DIR}/install/dlib/lib/${CMAKE_STATIC_LIBRARY_PREFIX}dlib${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set_target_properties(dlib::dlib PROPERTIES
-      IMPORTED_LOCATION_DEBUG "${CMAKE_BINARY_DIR}/install/dlib/lib/${CMAKE_STATIC_LIBRARY_PREFIX}dlibd${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/install/dlib/lib/${CMAKE_STATIC_LIBRARY_PREFIX}dlib${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/install/dlib/include"
       )
+
+    if(MSVC)
+      set_target_properties(dlib::dlib PROPERTIES
+        IMPORTED_LOCATION_DEBUG "${CMAKE_BINARY_DIR}/install/dlib/lib/${CMAKE_STATIC_LIBRARY_PREFIX}dlibd${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        )
+    endif()
+  else()
+    set_target_properties(dlib::dlib PROPERTIES
+      IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/install/dlib/lib64/${CMAKE_STATIC_LIBRARY_PREFIX}dlib${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/install/dlib/include"
+      )
+
+    if(MSVC)
+      set_target_properties(dlib::dlib PROPERTIES
+        IMPORTED_LOCATION_DEBUG "${CMAKE_BINARY_DIR}/install/dlib/lib64/${CMAKE_STATIC_LIBRARY_PREFIX}dlibd${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        )
+    endif()
   endif()
 endif()


### PR DESCRIPTION
Issue when compiling in alpine it uses the lib64 folder.
To fix this a check was added to see if the dlib/lib folder exists otherwise use dlib/lib64