### PR TITLE
sendCommand has already prefixed "*". Adapter processes this as inval…

### DIFF
--- a/src/adapter/shdr/connector.cpp
+++ b/src/adapter/shdr/connector.cpp
@@ -319,7 +319,7 @@ namespace mtconnect {
         if (!ec)
         {
           LOG(debug) << "Sending heartbeat";
-          sendCommand("* PING");
+          sendCommand("PING");
           m_heartbeatTimer.expires_from_now(m_heartbeatFrequency);
           m_heartbeatTimer.async_wait(
               asio::bind_executor(m_strand, boost::bind(&Connector::heartbeat, this, _1)));


### PR DESCRIPTION
…id message and later disconnects the connection for missing heartbeat.