### PR TITLE
Couple of minor fixes

### DIFF
--- a/src/configuration/agent_config.cpp
+++ b/src/configuration/agent_config.cpp
@@ -185,8 +185,8 @@ namespace mtconnect::configuration {
     }
     catch (std::exception &e)
     {
-      LOG(fatal) << "Agent failed to load: " << e.what() << " from " << m_configFile;
-      cerr << "Agent failed to load: " << e.what() << " from " << m_configFile << std::endl;
+      cerr << std::endl << "Agent failed to load: " << e.what() << " from " << m_configFile << std::endl;
+      LOG(fatal) << std::endl << "Agent failed to load: " << e.what() << " from " << m_configFile;
       usage(1);
     }
   }

--- a/src/configuration/service.cpp
+++ b/src/configuration/service.cpp
@@ -218,6 +218,10 @@ namespace mtconnect {
             usage(1);
           }
         }
+        else
+        {
+          usage(1);
+        }
 
         g_service = this;
         m_isService = true;


### PR DESCRIPTION
1. Avoid exception when no command line argument is present (Windows only)
2. Show the error message to console first because exception may be due to log file handling; like problem in creating the log files. 